### PR TITLE
Check api for last upload date

### DIFF
--- a/mtp_transaction_uploader/settings.py
+++ b/mtp_transaction_uploader/settings.py
@@ -13,5 +13,4 @@ API_CLIENT_ID = os.environ.get('API_CLIENT_ID', 'bank-admin')
 API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'bank-admin')
 API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 
-DS_LAST_DATE_FILE = os.environ.get('DS_LAST_DATE_FILE', '/tmp/ds_last_date')
 DS_NEW_FILES_DIR = os.environ.get('DS_NEW_FILES_DIR', '/tmp/ds_new_files')

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import io
 from unittest import mock, TestCase
 
 from mtp_transaction_uploader import upload
@@ -251,17 +250,18 @@ class RetrieveNewFilesTestCase(TestCase):
     @mock.patch('mtp_transaction_uploader.upload.settings')
     @mock.patch('mtp_transaction_uploader.upload.os')
     @mock.patch('mtp_transaction_uploader.upload.shutil')
-    @mock.patch('builtins.open')
+    @mock.patch('mtp_transaction_uploader.upload.get_authenticated_connection')
     def test_retrieve_new_files(
         self,
-        mock_open,
+        mock_get_connection,
         mock_shutil,
         mock_os,
         mock_settings,
         mock_connection_class
     ):
-        mock_os.path.exists.side_effect = [False, True]
-        mock_open.return_value = io.StringIO("111214")
+        mock_os.path.exists.side_effect = [False]
+        mock_get_connection().bank_admin.transactions.get.return_value =\
+            {'count': 1, 'results': [{'received_at': '2014-12-115T19:09:02Z'}]}
 
         dirlist = [
             'Y01A.CARS.#D.444444.D091214',
@@ -297,17 +297,18 @@ class RetrieveNewFilesTestCase(TestCase):
     @mock.patch('mtp_transaction_uploader.upload.settings')
     @mock.patch('mtp_transaction_uploader.upload.os')
     @mock.patch('mtp_transaction_uploader.upload.shutil')
-    @mock.patch('builtins.open')
+    @mock.patch('mtp_transaction_uploader.upload.get_authenticated_connection')
     def test_retrieve_new_files_no_files_available(
         self,
-        mock_open,
+        mock_get_connection,
         mock_shutil,
         mock_os,
         mock_settings,
         mock_connection_class
     ):
-        mock_os.path.exists.side_effect = [False, True]
-        mock_open.return_value = io.StringIO("111214")
+        mock_os.path.exists.side_effect = [False]
+        mock_get_connection().bank_admin.transactions.get.return_value =\
+            {'count': 1, 'results': [{'received_at': '2014-12-115T19:09:02Z'}]}
 
         dirlist = []
 


### PR DESCRIPTION
This is to avoid using what is, in our deployments, ephemeral
storage to record this piece of information, and avoid duplicate
uploads.