### PR TITLE
Alter categorisation of transactions based on statement info

### DIFF
--- a/mtp_transaction_uploader/upload.py
+++ b/mtp_transaction_uploader/upload.py
@@ -147,6 +147,7 @@ def get_transactions_from_file(data_services_file):
             transaction = {
                 'amount': record.amount,
                 'category': 'credit',
+                'source': 'bank_transfer',
                 'sender_sort_code': record.originators_sort_code,
                 'sender_account_number': record.originators_account_number,
                 'sender_name': record.transaction_description,
@@ -164,7 +165,8 @@ def get_transactions_from_file(data_services_file):
         elif record.is_credit() and not record.is_total():
             transaction = {
                 'amount': record.amount,
-                'category': 'non-payment-credit',
+                'category': 'credit',
+                'source': 'administrative',
                 'sender_sort_code': record.originators_sort_code,
                 'sender_account_number': record.originators_account_number,
                 'sender_name': record.transaction_description,
@@ -177,6 +179,7 @@ def get_transactions_from_file(data_services_file):
             transaction = {
                 'amount': record.amount,
                 'category': 'debit',
+                'source': 'administrative',
                 'sender_sort_code': record.originators_sort_code,
                 'sender_account_number': record.originators_account_number,
                 'sender_name': record.transaction_description,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -344,6 +344,7 @@ class TransactionsFromFileTestCase(TestCase):
 
         # transaction 0 - debit
         self.assertEqual(transactions[0]['category'], 'debit')
+        self.assertEqual(transactions[0]['source'], 'administrative')
         self.assertEqual(transactions[0]['amount'], 288615)
         self.assertEqual(transactions[0]['received_at'], '2004-02-05T00:00:00')
 
@@ -353,6 +354,7 @@ class TransactionsFromFileTestCase(TestCase):
 
         # transaction 1 - credit
         self.assertEqual(transactions[1]['category'], 'credit')
+        self.assertEqual(transactions[1]['source'], 'bank_transfer')
         self.assertEqual(transactions[1]['amount'], 8939)
         self.assertEqual(transactions[1]['received_at'], '2004-02-05T00:00:00')
         self.assertEqual(transactions[1]['sender_account_number'], '29696666')
@@ -363,6 +365,7 @@ class TransactionsFromFileTestCase(TestCase):
 
         # transaction 2 - credit
         self.assertEqual(transactions[2]['category'], 'credit')
+        self.assertEqual(transactions[2]['source'], 'bank_transfer')
         self.assertEqual(transactions[2]['amount'], 9802)
         self.assertEqual(transactions[2]['received_at'], '2004-02-05T00:00:00')
         self.assertEqual(transactions[2]['sender_account_number'], '78990056')


### PR DESCRIPTION
Credits and debits are now recorded as such, and transactions which
are not payments to a prisoner are recorded as "administrative".

Requires: https://github.com/ministryofjustice/money-to-prisoners-api/pull/110