### PR TITLE
Fix parsing exception caused by 3 digit year and others

### DIFF
--- a/mtp_transaction_uploader/patterns.py
+++ b/mtp_transaction_uploader/patterns.py
@@ -2,13 +2,17 @@ import re
 
 CREDIT_REF_PATTERN = re.compile(
     '''
+    ^
+    [^a-zA-Z]*                    # skip until first letter
     ([A-Za-z][0-9]{4}[A-Za-z]{2}) # match the prisoner number
-    .*?                           # skip until next digit
+    \D*                           # skip until next digit
     ([0-9]{1,2})                  # match 1 or 2 digit day of month
-    .*?                           # skip until next digit
+    \D*                           # skip until next digit
     ([0-9]{1,2})                  # match 1 or 2 digit month
-    .*?                           # skip until next digit
-    ([0-9]{2,4})                  # match 2 or 4 digit year
+    \D*                           # skip until next digit
+    ([0-9]{4}|[0-9]{2})           # match 4 or 2 digit year
+    \D*                           # skip until end
+    $
     ''',
     re.X
 )

--- a/mtp_transaction_uploader/upload.py
+++ b/mtp_transaction_uploader/upload.py
@@ -170,11 +170,13 @@ def parse_credit_reference(ref):
             try:
                 dob = datetime.strptime(date_str, '%d/%m/%Y')
             except ValueError:
-                dob = datetime.strptime(date_str, '%d/%m/%y')
-
-                # set correct century for 2 digit year
-                if dob.year > datetime.today().year - 10:
-                    dob = dob.replace(year=dob.year - 100)
+                try:
+                    dob = datetime.strptime(date_str, '%d/%m/%y')
+                    # set correct century for 2 digit year
+                    if dob.year > datetime.today().year - 10:
+                        dob = dob.replace(year=dob.year - 100)
+                except ValueError:
+                    return
 
             ParsedReference = namedtuple('ParsedReference',
                                          ['prisoner_number', 'prisoner_dob'])

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,6 +18,21 @@ class CreditReferenceParsingTestCase(TestCase):
             'A1234GY 09/12/86', 'A1234GY', date(1986, 12, 9)
         )
 
+    def test_trailing_whitespace_parses(self):
+        self._test_successful_parse(
+            'A1234GY 09/12/86        ', 'A1234GY', date(1986, 12, 9)
+        )
+
+    def test_leading_whitespace_parses(self):
+        self._test_successful_parse(
+            '      A1234GY 09/12/86', 'A1234GY', date(1986, 12, 9)
+        )
+
+    def test_trailing_non_digits_parses(self):
+        self._test_successful_parse(
+            'A1234GY 09/12/86.', 'A1234GY', date(1986, 12, 9)
+        )
+
     def test_no_space_parses(self):
         self._test_successful_parse(
             'A1234GY09/12/86', 'A1234GY', date(1986, 12, 9)
@@ -35,7 +50,12 @@ class CreditReferenceParsingTestCase(TestCase):
 
     def test_non_separated_date_parses(self):
         self._test_successful_parse(
-            'A1234GY 091286', 'A1234GY', date(1986, 12, 9)
+            'A1234GY091286', 'A1234GY', date(1986, 12, 9)
+        )
+
+    def test_space_separated_date_parses(self):
+        self._test_successful_parse(
+            'A1234GY 09 12 86', 'A1234GY', date(1986, 12, 9)
         )
 
     def test_non_zero_padded_date_parses(self):
@@ -48,11 +68,29 @@ class CreditReferenceParsingTestCase(TestCase):
             'A1234GY 09/12/1986', 'A1234GY', date(1986, 12, 9)
         )
 
-    def test_invalid_prisoner_number_does_not_parse(self):
+    def test_invalid_prisoner_number_does_not_parse_1(self):
         self.assertEqual(upload.parse_credit_reference('A1234Y 09/12/1986'), None)
 
-    def test_invalid_year_does_not_parse(self):
+    def test_invalid_prisoner_number_does_not_parse_2(self):
+        self.assertEqual(upload.parse_credit_reference('AA1234GY 09/12/1986'), None)
+
+    def test_one_digit_year_does_not_parse(self):
         self.assertEqual(upload.parse_credit_reference('A1234GY 1/1/1'), None)
+
+    def test_three_digit_year_does_not_parse(self):
+        self.assertEqual(upload.parse_credit_reference('A1234GY 09/12/198'), None)
+
+    def test_too_many_date_digits_does_not_parse(self):
+        self.assertEqual(upload.parse_credit_reference('A1234GY 0931231986'), None)
+
+    def test_trailing_digits_does_not_parse(self):
+        self.assertEqual(upload.parse_credit_reference('A1234GY 09/12/198600000'), None)
+
+    def test_impossible_day_does_not_parse(self):
+        self.assertEqual(upload.parse_credit_reference('A1234GY 32/12/1986'), None)
+
+    def test_impossible_month_does_not_parse(self):
+        self.assertEqual(upload.parse_credit_reference('A1234GY 09/13/1986'), None)
 
 
 class FilenameParsingTestCase(TestCase):


### PR DESCRIPTION
Avoids parsing exception due to 3 digit year or impossible date and
month.

Also some other stuff.