### PR TITLE
Fix date parsing from filename where full path is given

### DIFF
--- a/mtp_transaction_uploader/upload.py
+++ b/mtp_transaction_uploader/upload.py
@@ -56,7 +56,7 @@ def parse_filename(filename, account_code):
     file_pattern = re.compile(
         FILE_PATTERN_STR % {'code': account_code}, re.X
     )
-    m = file_pattern.match(filename)
+    m = file_pattern.search(filename)
     if m:
         return datetime.strptime(m.group('date'), DATE_FORMAT)
     return None

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -117,6 +117,12 @@ class FilenameParsingTestCase(TestCase):
         parsed_datetime = upload.parse_filename(filename, '444444')
         self.assertEqual(None, parsed_datetime)
 
+    def test_parsing_date_from_full_path_succeeds(self):
+        filename = '/random/Y01A.CARS.#D.444444.D091214'
+        expected_date = date(2014, 12, 9)
+        parsed_datetime = upload.parse_filename(filename, '444444')
+        self.assertEqual(expected_date, parsed_datetime.date())
+
 
 @mock.patch('mtp_transaction_uploader.upload.settings')
 @mock.patch('mtp_transaction_uploader.upload.Connection')


### PR DESCRIPTION
This is for the subsequent use of parse_filename on the local file.