### PR TITLE
Update app to use new mtp-common package

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -21,7 +21,7 @@ def setup_monitoring():
                 'datefmt': '%Y-%m-%dT%H:%M:%S',
             },
             'elk': {
-                '()': 'mtp_utils.logging.ELKFormatter'
+                '()': 'mtp_common.logging.ELKFormatter'
             }
         },
         'handlers': {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-utils[testing]==0.12
+money-to-prisoners-common[testing]==3.0.2
 
 nose>=1.3

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,4 +1,4 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-utils[monitoring]==0.12
+money-to-prisoners-common[monitoring]==3.0.2

--- a/tests/test_code_style.py
+++ b/tests/test_code_style.py
@@ -1,4 +1,4 @@
 import os
-from mtp_utils.test_utils.code_style import CodeStyleTestCase  # noqa
+from mtp_common.test_utils.code_style import CodeStyleTestCase  # noqa
 
 CodeStyleTestCase.root_path = os.path.join(os.path.dirname(__file__), os.path.pardir)


### PR DESCRIPTION
This new package combines the previous mtp-common, utils and user-admin
packages. In this case it is only relevant for testing and logging.