### PR TITLE
MTP-1537: Removed duplicated dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,8 +3,5 @@
 money-to-prisoners-common~=10.1.0
 
 pysftp==0.2.9
-requests-oauthlib>=1,<2
-slumber>=0.7,<0.8
-pytz>=2019.1
 
 bankline-direct-parser==0.4


### PR DESCRIPTION
Removed dependencies already provided by `mtp-common` package.

**NOTE**: `pysftp` and `bankline-direct-parser` seem to be unique of this
application so it's fine to leave these here as additional requirements.

See
---
- [mtp-common-10.1.0 dependencies](https://github.com/ministryofjustice/money-to-prisoners-common/blob/905023f9e99468dd90d984a8ecc1c25deb6c08ec/setup.py#L18-L35)
- [Ticket MTP-1537](https://dsdmoj.atlassian.net/browse/MTP-1537)