### PR TITLE
Log variable data using a template string

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=10.1.0
+money-to-prisoners-common~=11.4.0
 
 pysftp==0.2.9
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=10.1.0
+money-to-prisoners-common[testing]~=11.4.0
 
 -r base.txt
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -735,10 +735,14 @@ class TransactionsFromFileTestCase(TestCase):
 
         transactions = upload.get_transactions_from_file(data_services_file)
         mock_logger.error.assert_called_with(
-            "Errors: {'account 0': ['Monetary total of debit items does not "
-            "match expected: counted 288615, expected 288610', "
-            "'Monetary total of credit items does not match expected: "
-            "counted 18741, expected 18732']}")
+            'Errors: %s',
+            {
+                'account 0': [
+                    'Monetary total of debit items does not match expected: counted 288615, expected 288610',
+                    'Monetary total of credit items does not match expected: counted 18741, expected 18732',
+                ]
+            }
+        )
 
         self.assertEqual(transactions, None)
 


### PR DESCRIPTION
…rather than an immediately formatted string. This allows Sentry to group messages by template, but still fully renders messages in the console.

[MTP-1863](https://dsdmoj.atlassian.net/browse/MTP-1863)

Depends on [common#419](https://github.com/ministryofjustice/money-to-prisoners-common/pull/419)