### PR TITLE
Use mtp-common 12.x: Only support Python 3.8+

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.4.0
+money-to-prisoners-common~=12.0.0
 
 pysftp==0.2.9
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.4.0
+money-to-prisoners-common[testing]~=12.0.0
 
 -r base.txt
 


### PR DESCRIPTION
As part of the migration to a newer version of Ubuntu (`20.04`) which
comes with Python 3.8.

Related to ticket: https://dsdmoj.atlassian.net/browse/MTP-1841