### PR TITLE
Turn on Sentry.io performance monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,8 @@ def setup_monitoring():
             dsn=settings.SENTRY_DSN,
             environment=settings.ENVIRONMENT,
             release=settings.APP_GIT_COMMIT,
-            send_default_pii=False
+            send_default_pii=False,
+            traces_sample_rate=1.0,
         )
     logging.config.dictConfig(logging_conf)
     logger = logging.getLogger('mtp')


### PR DESCRIPTION
…at 100% sample rate in production (this app is a scheduled job that only runs once a day)