### PR TITLE
Switch patching by CircleCI's deployment step to new resource type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
               IMAGE=${registry}:${tag}
               kubectl patch configmap app-versions --patch "{\"data\": {\"${app}\": \"${version}\"}}"
               # NB: patching operations assume that ONLY ONE container exists
-              kubectl patch tzcronjob ${app} --type json --patch "[{\"op\": \"replace\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"${IMAGE}\"}]"
+              kubectl patch cronjob ${app} --type json --patch "[{\"op\": \"replace\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"${IMAGE}\"}]"
             else
               echo "Not deploying to test"
             fi


### PR DESCRIPTION
… because TZCronJobs have been replaced with regular CronJobs since the new EKS cluster dropped support for the former type