### PR TITLE
MTP-1980: Replace deprecated `deploy` step in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: |
             . /tmp/mtp-env.sh
             docker logout ${ECR_REGISTRY}
-      - deploy:
+      - run:
           name: Deploy to test
           command: |
             if [[ "${CIRCLE_BRANCH}" == "main" ]]; then


### PR DESCRIPTION
…anti-concurrency protection can be dropped since there is no parallelism in this workflow anyway.
[ref](https://circleci.com/docs/migrate-from-deploy-to-run/)