### PR TITLE
Bumped mtp-common to `19.0.0` (from `17.1.0`)

### DIFF
--- a/mtp_transaction_uploader/upload.py
+++ b/mtp_transaction_uploader/upload.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import datetime
+from datetime import timezone
 import itertools
 import logging
 import math
@@ -14,7 +15,6 @@ from mtp_common.bank_accounts import (
     is_correspondence_account, roll_number_required, roll_number_valid_for_account
 )
 from pysftp import Connection, CnOpts
-from pytz import utc
 from slumber.exceptions import SlumberHttpBaseException
 
 from mtp_transaction_uploader import settings
@@ -165,7 +165,7 @@ def get_transactions_from_file(data_services_file):
             continue
 
         sender_information = extract_sender_information(record)
-        received_at = datetime.datetime.combine(record.date, datetime.time(12, 0, 0, tzinfo=utc))
+        received_at = datetime.datetime.combine(record.date, datetime.time(12, 0, 0, tzinfo=timezone.utc))
         transaction = {
             'amount': record.amount,
             'sender_sort_code': sender_information.sort_code,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=18.0.0
+money-to-prisoners-common~=19.0.0
 
 pysftp~=0.2.9
 bankline-direct-parser==0.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=17.1.0
+money-to-prisoners-common~=18.0.0
 
 pysftp~=0.2.9
 bankline-direct-parser==0.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=18.0.0
+money-to-prisoners-common[testing]~=19.0.0
 
 -r base.txt
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=17.1.0
+money-to-prisoners-common[testing]~=18.0.0
 
 -r base.txt
 


### PR DESCRIPTION
The main change in mtp-common is the upgrade to Django 5.1 from Django 3.2. However this _shouldn't_ affect this application as it's a plain Python script rather than a Django web application.

However dependencies mtp-common's dependencies were probably bumped as a result.

The main change in this application is [the removal of the use of `pytz.utc`](https://github.com/ministryofjustice/money-to-prisoners-transaction-uploader/commit/95f44a272d4654c55603e19c39fbaa51e81e9c29) in favour of using Python's standard `datetime.timezone.utc`.