### PR TITLE
IR-1782 Deploy to test from GHCR, not ECR

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -127,7 +127,7 @@ jobs:
         env:
           TAG: ${{ steps.tags.outputs.tag }}
           VERSION: ${{ steps.tags.outputs.version }}
-          REGISTRY: ${{ steps.tags.outputs.registry }}
+          GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
           K8S_CLUSTER_CERT: ${{ secrets.K8S_CLUSTER_CERT }}
           K8S_CLUSTER_NAME: ${{ secrets.K8S_CLUSTER_NAME }}
           K8S_CLUSTER_SERVER: ${{ secrets.K8S_CLUSTER_SERVER }}
@@ -140,6 +140,6 @@ jobs:
           kubectl config set-credentials github-actions --token=${K8S_TOKEN}
           kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=github-actions --namespace=${K8S_NAMESPACE}
           kubectl config use-context ${K8S_CLUSTER_NAME}
-          IMAGE=${REGISTRY}:${TAG}
+          IMAGE=${GHCR_PACKAGE}:${VERSION}
           kubectl patch configmap app-versions --patch "{\"data\": {\"transaction-uploader\": \"${VERSION}\"}}"
           kubectl patch cronjob transaction-uploader --type json --patch "[{\"op\": \"replace\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"${IMAGE}\"}]"


### PR DESCRIPTION
Fixes test drifting back to ECR after `app apply test`.

## The symptom

After an `app apply test`, three apps were still on ECR:

```
…/money-to-prisoners:api.main.b19fce1
…/money-to-prisoners:start-page.main.b8f0b65
…/money-to-prisoners:transaction-uploader.main.d2ea5b1
ghcr.io/…/money-to-prisoners-cashbook:main.52496da      <- the rest were fine
```

Not a config or a missing-image problem: all three versions return **HTTP 200**
from GHCR, and `apps.yml` marks all nine correctly. Those three are simply the
repos whose builds ran most recently.

## The cause

The `Deploy to test` step patches the deployment with `${REGISTRY}:${TAG}` — an
**ECR** reference — and every repo has `GHA_DEPLOY_ENABLED=true`. So every merge
to main puts that app back on ECR, silently undoing the last `app apply`. All
eight would have drifted, not just these three.

Phase 3 moved `app apply` to GHCR and left this behind. My mistake — the plan
called for it and I carried the phase 2 wording ("deploys are untouched") into
phase 3.

## The change

`IMAGE=${GHCR_PACKAGE}:${VERSION}`, matching what `app apply` renders.

Paired with ministryofjustice/money-to-prisoners-deploy#534, which fixes the
same class of bug in `_patch_resources` — the path `app deploy` and
`app promote` use, and therefore the one `deploy-prod.yml` relies on.

## Verified

All three paths — `app apply`, `app deploy`/`promote`, and this workflow step —
now agree for every app in both environments; test on GHCR except `deploy`,
prod entirely on ECR until #531.
