### PR TITLE
IR-1782 Build multi-arch images

### DIFF
--- a/.github/scripts/clean-ghcr.py
+++ b/.github/scripts/clean-ghcr.py
@@ -27,8 +27,10 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 API_ROOT = 'https://api.github.com'
-# the `[commit]` half of a `[branch].[commit]` image tag
-COMMIT_RE = re.compile(r'^[0-9a-f]{7,40}$')
+# the `[commit]` half of a `[branch].[commit]` image tag, optionally carrying the platform
+# suffix that the build pushes before the two platforms are merged; without the suffix these
+# would look like tags naming no branch, and so would never be cleaned up
+COMMIT_RE = re.compile(r'^[0-9a-f]{7,40}(-(amd64|arm64))?$')
 
 
 def clean_ghcr():

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -4,11 +4,19 @@ on:
   push:
 jobs:
   build-test-push:
-    name: Build, test and push
-    runs-on: ubuntu-latest
+    name: Build and test (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: amd64
+            runner: ubuntu-latest
+          - platform: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -33,9 +41,9 @@ jobs:
           echo "tag=${tag}"                     >> "$GITHUB_OUTPUT"
           echo "ghcr_package=${ghcr_package}"   >> "$GITHUB_OUTPUT"
           echo "ghcr_base=${ghcr_base}"         >> "$GITHUB_OUTPUT"
-          echo "Building ${tag}"
+          echo "Building ${tag} for linux/${{ matrix.platform }}"
 
-      # base images come from the public GHCR package, so this needs no credentials
+      
       - name: Pull base image
         env:
           GHCR_BASE: ${{ steps.tags.outputs.ghcr_base }}
@@ -56,6 +64,7 @@ jobs:
             --tag ${TAG} \
             .
 
+      
       - name: Test docker image
         env:
           TAG: ${{ steps.tags.outputs.tag }}
@@ -76,23 +85,61 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.platform }}
           path: /tmp/reports
           if-no-files-found: warn
 
+      
       - name: Push docker image
         env:
           TAG: ${{ steps.tags.outputs.tag }}
           VERSION: ${{ steps.tags.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
           GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
         run: |
-          echo "Pushing ${VERSION} to ${GHCR_PACKAGE}"
-          docker tag ${TAG} ${GHCR_PACKAGE}:${VERSION}
-          docker push ${GHCR_PACKAGE}:${VERSION}
+          echo "Pushing ${VERSION}-${PLATFORM} to ${GHCR_PACKAGE}"
+          docker tag ${TAG} ${GHCR_PACKAGE}:${VERSION}-${PLATFORM}
+          docker push ${GHCR_PACKAGE}:${VERSION}-${PLATFORM}
+
+  merge-and-deploy:
+    name: Merge platforms and deploy to test
+    needs: build-test-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log docker into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          branch_lc=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          version=${branch_lc}.${GITHUB_SHA::7}
+          ghcr_package=ghcr.io/${{ github.repository_owner }}/money-to-prisoners-transaction-uploader
+          echo "version=${version}"           >> "$GITHUB_OUTPUT"
+          echo "ghcr_package=${ghcr_package}" >> "$GITHUB_OUTPUT"
+
+      - name: Merge into a multi-arch manifest
+        env:
+          VERSION: ${{ steps.tags.outputs.version }}
+          GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
+        run: |
+          echo "Merging ${VERSION} from amd64 and arm64"
+          docker buildx imagetools create \
+            --tag ${GHCR_PACKAGE}:${VERSION} \
+            ${GHCR_PACKAGE}:${VERSION}-amd64 \
+            ${GHCR_PACKAGE}:${VERSION}-arm64
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-            echo "Pushing latest to ${GHCR_PACKAGE}"
-            docker tag ${TAG} ${GHCR_PACKAGE}:latest
-            docker push ${GHCR_PACKAGE}:latest
+            echo "Pointing latest at ${VERSION}"
+            docker buildx imagetools create \
+              --tag ${GHCR_PACKAGE}:latest \
+              ${GHCR_PACKAGE}:${VERSION}
           fi
 
       
@@ -105,7 +152,6 @@ jobs:
       - name: Deploy to test
         if: ${{ github.ref_name == 'main' && vars.GHA_DEPLOY_ENABLED == 'true' }}
         env:
-          TAG: ${{ steps.tags.outputs.tag }}
           VERSION: ${{ steps.tags.outputs.version }}
           GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
           K8S_CLUSTER_CERT: ${{ secrets.K8S_CLUSTER_CERT }}


### PR DESCRIPTION
Images here are `linux/amd64` only, so developers on Apple Silicon run them under emulation.

Each platform is now built and tested on a runner of its own architecture, pushed to `[branch].[sha]-[platform]`, then merged into one multi-arch index for the plain `[branch].[sha]` tag. The plain tag only appears once the build has passed.

**Blocked on ministryofjustice/money-to-prisoners-deploy#551** — this build pulls `base-web` for the runner's own architecture, so the base package must be multi-arch before this merges.

Generated from the shared template in money-to-prisoners-deploy; see #551 for the rationale and trade-offs.